### PR TITLE
bump version 0.10.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,8 @@ version: "{build}"
 
 # specify custom environment variables
 environment:
-  PYTHON_VERSION: 3.6
-  MINICONDA: C:\Miniconda36-x64
+  PYTHON_VERSION: 3.7
+  MINICONDA: C:\Miniconda37-x64
 
 # clone directory
 clone_folder: C:\projects\bigartm-install

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 mkdir C:\BigARTM
 cd C:\BigARTM
-wget "https://ci.appveyor.com/api/projects/bigartm/bigartm/artifacts/BigARTM.7z?branch=stable&job=Environment%3A%20PYTHON_VERSION%3D3.6%2C%20MINICONDA%3DC%3A%5CMiniconda36-x64" -OutFile "$pwd\BigARTM.7z"
+wget "https://ci.appveyor.com/api/projects/bigartm/bigartm/artifacts/BigARTM.7z?branch=stable&job=Environment%3A%20PYTHON_VERSION%3D3.6%2C%20MINICONDA%3DC%3A%5CMiniconda37-x64" -OutFile "$pwd\BigARTM.7z"
 7z.exe x .\BigARTM.7z
 
 cd protobuf\python

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ pip install protobuf
 pip install tqdm
 
 # Clone repository and build
-git clone --branch=v0.9.0 https://github.com/bigartm/bigartm.git
+git clone --branch=v0.10.0 https://github.com/bigartm/bigartm.git
 cd bigartm
 mkdir build && cd build
 cmake ..


### PR DESCRIPTION
1) Support the new version of python: python 3.7
2) Bump version of bigartm to 0.10.0 because of the new bug-fix: https://github.com/bigartm/bigartm/pull/947